### PR TITLE
Fix: `pretrained` argument handling for `dinov2` loading from torch hub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["uniception", "scripts"]
 
 [project]
 name = "uniception"
-version = "0.1.6"
+version = "0.1.7"
 description = "Generalizable Perception Stack for 3D, 4D, spatial AI and scene understanding"
 readme = "README.md"
 authors = [

--- a/uniception/models/encoders/dinov2.py
+++ b/uniception/models/encoders/dinov2.py
@@ -25,6 +25,7 @@ class DINOv2Encoder(UniCeptionViTEncoderBase):
         norm_returned_features: bool = True,
         pretrained_checkpoint_path: str = None,
         torch_hub_force_reload: bool = False,
+        torch_hub_pretrained: bool = True,
         gradient_checkpointing: bool = False,
         keep_first_n_layers: Optional[int] = None,
         use_pytorch_sdpa=True,
@@ -43,6 +44,7 @@ class DINOv2Encoder(UniCeptionViTEncoderBase):
             with_registers (bool): Whether to use the DINOv2 model with registers. Default: False
             pretrained_checkpoint_path (str): Path to the pretrained checkpoint if using custom trained version of DINOv2. Default: None
             torch_hub_force_reload (bool): Whether to force reload the model from torch hub. Default: False
+            torch_hub_pretrained (bool): Whether to use the pretrained weights from torch hub. Default: True
             gradient_checkpointing (bool): Whether to use gradient checkpointing to save GPU memory during backward call. Default: False
             keep_first_n_layers (Optional[int]): If specified, only the first n layers of the model will be kept. Default: None
             use_pytorch_sdpa (bool): Whether to use PyTorch native SDPA for attention layers. Default: True
@@ -90,9 +92,14 @@ class DINOv2Encoder(UniCeptionViTEncoderBase):
                 "facebookresearch/dinov2",
                 DINO_MODELS[self.with_registers][self.version],
                 force_reload=torch_hub_force_reload,
+                pretrained=torch_hub_pretrained if pretrained_checkpoint_path is None else False,
             )
         except:  # Load from cache
-            self.model = torch.hub.load("facebookresearch/dinov2", DINO_MODELS[self.with_registers][self.version])
+            self.model = torch.hub.load(
+                "facebookresearch/dinov2",
+                DINO_MODELS[self.with_registers][self.version],
+                pretrained=torch_hub_pretrained if pretrained_checkpoint_path is None else False,
+            )
 
         del (
             self.model.mask_token

--- a/uniception/models/encoders/dune.py
+++ b/uniception/models/encoders/dune.py
@@ -94,11 +94,13 @@ class DUNEEncoder(UniCeptionViTEncoderBase):
                 "facebookresearch/dinov2",
                 DINO_MODELS[self.with_registers][self.version],
                 force_reload=torch_hub_force_reload,
+                pretrained=False,
             )
         except:  # Load from cache
             self.model = torch.hub.load(
                 "facebookresearch/dinov2",
                 DINO_MODELS[self.with_registers][self.version],
+                pretrained=False,
             )
 
         del (


### PR DESCRIPTION
This PR fixes the issue #17.

There is no way for `dinov2` to not load pretrained weights from torch hub even if weights are loaded from separate checkpoint [facebookresearch/map-anything#49](https://github.com/facebookresearch/map-anything/issues/149).

Changes:
- Added `torch_hub_pretrained=True` argument to `DINOv2Encoder` class. 
- Added logic that prevents weights download/loading if `torch_hub_pretrained` is set to `False` or `pretrained_checkpoint_path` is not `None`.
- Added `pretrained=False` to `torch.hub.load` call in `DUNEEncoder` to prevent `dinov2` weights being loaded/downloaded as checkpoint path is required to initialize the class.